### PR TITLE
fix: fix ach file origin id/company id

### DIFF
--- a/ach/record_types/batch_header.py
+++ b/ach/record_types/batch_header.py
@@ -14,6 +14,7 @@ from .record_fields import (
     DateFieldType,
     FieldDefinition,
     IntegerFieldType,
+    IntegerFieldSpacePaddingType,
 )
 from .record_type_base import RecordType
 
@@ -40,7 +41,7 @@ class BatchHeaderRecordType(RecordType):
             "Company Discretionary Data", AlphaNumFieldType, length=20, required=False
         ),
         "company_identification": FieldDefinition(
-            "Company Identification Number", AlphaNumFieldType, length=10
+            "Company Identification Number", IntegerFieldSpacePaddingType, length=10
         ),
         "standard_entry_class_code": FieldDefinition(
             "Standard Entry Class Code",

--- a/ach/record_types/file_header.py
+++ b/ach/record_types/file_header.py
@@ -18,6 +18,7 @@ from .record_fields import (
     TimeFieldType,
     FieldDefinition,
     IntegerFieldType,
+    IntegerFieldSpacePaddingType,
 )
 from .record_type_base import RecordType
 
@@ -46,7 +47,7 @@ class FileHeaderRecordType(RecordType):
         ),
         "origin_id": FieldDefinition(
             "Immediate Origin Routing or Company ID",
-           AlphaNumFieldType,
+           IntegerFieldSpacePaddingType,
             length=10,
         ),
         "file_creation_date": FieldDefinition(

--- a/ach/record_types/record_fields.py
+++ b/ach/record_types/record_fields.py
@@ -184,6 +184,15 @@ class AlphaNumFieldType(FieldType):
             return input_string
         return re.sub(re.compile(r"[^A-Za-z0-9./()&\'\s-]"), "", input_string)
 
+class IntegerFieldSpacePaddingType(FieldType):
+    """Represents an integer field type. Pads number strings with leading 0s."""
+
+    padding: str = " "
+    alignment: Alignment = Alignment.RIGHT
+    regex: re.Pattern = re.compile(r"^\d+$")
+    auto_correct: bool = False
+
+
 
 class BlankPaddedRoutingNumberFieldType(IntegerFieldType):
     """Represents a routing number padded with a leading blank space."""


### PR DESCRIPTION
* add a new field type called `IntegerFieldSpacePaddingType`
* use  `IntegerFieldSpacePaddingType` for `origin_id` and `company_identification` fields 